### PR TITLE
Fix: The CJS build of Vite's Node API is deprecated.

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},


### PR DESCRIPTION
Fix: The CJS build of Vite's Node API is deprecated. See https://vite.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.